### PR TITLE
Add curly rule for statement after flow control clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This repository adheres to semantic versioning and follows the conventions of [k
 
 ## [Unreleased]
 
+## [0.9.0] - 2022-05-31
+### Added
+- ESLint rule `curly` to automatically fix inline code body for `if`, `else`, `for` and `while` etc
+
 ## [0.8.0] - 2022-03-29
 ### Added
 - New `simple-import-sort/imports` linting rule and `simple-import-sort` peer dependency
@@ -56,7 +60,8 @@ This repository adheres to semantic versioning and follows the conventions of [k
 - `babel`, `common`, `flow`, `mocha`, `node` and `typecript` Configs
 - `common`, `flowService` and `typescriptService` Presets
 
-[Unreleased]: https://github.com/spoke-ph/eslint-config-spoke/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/spoke-ph/eslint-config-spoke/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/spoke-ph/eslint-config-spoke/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/spoke-ph/eslint-config-spoke/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/spoke-ph/eslint-config-spoke/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/spoke-ph/eslint-config-spoke/compare/v0.5.0...v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This repository adheres to semantic versioning and follows the conventions of [k
 ## [0.9.0] - 2022-05-31
 ### Added
 - ESLint rule `curly` to automatically fix inline code body for `if`, `else`, `for` and `while` etc
+- ESLint rule `@typescript-eslint/indent` to typescript config to automatically fix Typescript node indentation issues
 
 ### Changed
 - Moved `eslint-plugin-simple-import-sort` from `peerDependencies` to `dependencies`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This repository adheres to semantic versioning and follows the conventions of [k
 ### Added
 - ESLint rule `curly` to automatically fix inline code body for `if`, `else`, `for` and `while` etc
 
+### Changed
+- Moved `eslint-plugin-simple-import-sort` from `peerDependencies` to `dependencies`
+
 ## [0.8.0] - 2022-03-29
 ### Added
 - New `simple-import-sort/imports` linting rule and `simple-import-sort` peer dependency

--- a/configs/common.js
+++ b/configs/common.js
@@ -61,6 +61,7 @@ module.exports = {
       exports: "never",
       functions: "never"
     }],
-    "simple-import-sort/imports": "error"
+    "simple-import-sort/imports": "error",
+    "curly": ["error"]
   }
 };

--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -1,78 +1,78 @@
 module.exports = {
-  "parser": "@typescript-eslint/parser",
-  "parserOptions": {
-      "project": "tsconfig.json",
-      "sourceType": "module"
-  },
-  "plugins": [
-      "@typescript-eslint",
-  ],
-  "rules": {
-      "@typescript-eslint/naming-convention": ["error",
-        {
-          selector: "default",
-          format: ["camelCase"],
-          leadingUnderscore: "allow"
-        },
-        {
-          selector: "variable",
-          format: ["camelCase", "UPPER_CASE", "PascalCase"],
-          leadingUnderscore: "allow"
-        },
-        {
-          selector: "function",
-          format: ["camelCase"],
-          leadingUnderscore: "allow"
-        },
-        {
-          selector: ["typeLike", "typeAlias", "typeParameter"],
-          format: ["PascalCase"],
-          leadingUnderscore: "allow"
-        },
-        {
-          selector: "enumMember",
-          format: ["PascalCase", "camelCase"]
-        },
-        {
-          selector: ["typeProperty", "typeAlias", "typeParameter"],
-          format: ["PascalCase", "camelCase"],
-          leadingUnderscore: "allow"
-        },
-        {
-          selector: ["objectLiteralProperty", "objectLiteralMethod"],
-          format: ["camelCase", "UPPER_CASE", "PascalCase", "snake_case"] // snake_case is for some external APIs and libraries
-        }
-      ],
-      "@typescript-eslint/member-delimiter-style": [
-          "error",
-          {
-              "multiline": {
-                  "delimiter": "semi",
-                  "requireLast": true
-              },
-              "singleline": {
-                  "delimiter": "semi",
-                  "requireLast": false
-              }
-          }
-      ],
-      "@typescript-eslint/prefer-namespace-keyword": "error",
-      "@typescript-eslint/no-unused-vars": ["error"],
-      "@typescript-eslint/semi": [
-          "error",
-          "always"
-      ],
-      "@typescript-eslint/space-within-parens": [
-          "off",
-          "never"
-      ],
-      "@typescript-eslint/type-annotation-spacing": "error",
-      "@typescript-eslint/indent": [
-        "error",
-        2,
-        {
-          SwitchCase: 1
-        }
-      ],
-  }
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+        "project": "tsconfig.json",
+        "sourceType": "module"
+    },
+    "plugins": [
+        "@typescript-eslint",
+    ],
+    "rules": {
+        "@typescript-eslint/naming-convention": ["error",
+            {
+                selector: "default",
+                format: ["camelCase"],
+                leadingUnderscore: "allow"
+            },
+            {
+                selector: "variable",
+                format: ["camelCase", "UPPER_CASE", "PascalCase"],
+                leadingUnderscore: "allow"
+            },
+            {
+                selector: "function",
+                format: ["camelCase"],
+                leadingUnderscore: "allow"
+            },
+            {
+                selector: ["typeLike", "typeAlias", "typeParameter"],
+                format: ["PascalCase"],
+                leadingUnderscore: "allow"
+            },
+            {
+                selector: "enumMember",
+                format: ["PascalCase", "camelCase"]
+            },
+            {
+                selector: ["typeProperty", "typeAlias", "typeParameter"],
+                format: ["PascalCase", "camelCase"],
+                leadingUnderscore: "allow"
+            },
+            {
+                selector: ["objectLiteralProperty", "objectLiteralMethod"],
+                format: ["camelCase", "UPPER_CASE", "PascalCase", "snake_case"] // snake_case is for some external APIs and libraries
+            }
+        ],
+        "@typescript-eslint/member-delimiter-style": [
+            "error",
+            {
+                "multiline": {
+                    "delimiter": "semi",
+                    "requireLast": true
+                },
+                "singleline": {
+                    "delimiter": "semi",
+                    "requireLast": false
+                }
+            }
+        ],
+        "@typescript-eslint/prefer-namespace-keyword": "error",
+        "@typescript-eslint/no-unused-vars": ["error"],
+        "@typescript-eslint/semi": [
+            "error",
+            "always"
+        ],
+        "@typescript-eslint/space-within-parens": [
+            "off",
+            "never"
+        ],
+        "@typescript-eslint/type-annotation-spacing": "error",
+        "@typescript-eslint/indent": [
+            "error",
+            2,
+            {
+                SwitchCase: 1
+            }
+        ],
+    }
 };

--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -66,6 +66,13 @@ module.exports = {
           "off",
           "never"
       ],
-      "@typescript-eslint/type-annotation-spacing": "error"
+      "@typescript-eslint/type-annotation-spacing": "error",
+      "@typescript-eslint/indent": [
+        "error",
+        2,
+        {
+          SwitchCase: 1
+        }
+      ],
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-spoke",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,11 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
+    "eslint-plugin-simple-import-sort": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
+      "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw=="
+    },
     "gitconfiglocal": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-spoke",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Spoke's ESLint config",
   "license": "Unlicense",
   "author": {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,10 @@
     "babel-eslint": "^10.0.3",
     "eslint": "^7.21.0",
     "eslint-plugin-flowtype": "^5.3.1",
-    "eslint-plugin-simple-import-sort": "^7.0.0",
     "@typescript-eslint/parser": "^4.15.2",
     "@typescript-eslint/eslint-plugin": "^4.15.2"
+  },
+  "dependencies": {
+    "eslint-plugin-simple-import-sort": "^7.0.0"
   }
 }


### PR DESCRIPTION
- `curly`, these will fail:

```
if (foo) foo++;

while (bar)
    baz();

if (foo) {
    baz();
} else qux();
```

- `@typescript-eslint/indent` will fix:

```
interface DbInput<EntityType extends object> {
      tableName: string;
    }
```