### PR TITLE
Peer dependencies can now use newer major versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This repository adheres to semantic versioning and follows the conventions of [k
 
 ## [Unreleased]
 
+## [1.1.0] - 2022-10-03
+### Changed
+- Peer dependencies can now use newer major versions
+
 ## [1.0.0] - 2022-10-03
 ### Changed
 - **BREAKING** Upgrade peer dependencies: Users of this library must upgrade the following libraries
@@ -79,7 +83,8 @@ This repository adheres to semantic versioning and follows the conventions of [k
 - `babel`, `common`, `flow`, `mocha`, `node` and `typecript` Configs
 - `common`, `flowService` and `typescriptService` Presets
 
-[Unreleased]: https://github.com/spoke-ph/eslint-config-spoke/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/spoke-ph/eslint-config-spoke/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/spoke-ph/eslint-config-spoke/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/spoke-ph/eslint-config-spoke/compare/v0.11.0...v1.0.0
 [0.11.0]: https://github.com/spoke-ph/eslint-config-spoke/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/spoke-ph/eslint-config-spoke/compare/v0.9.0...v0.10.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-config-spoke",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-config-spoke",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Unlicense",
       "dependencies": {
         "eslint-plugin-simple-import-sort": "^7.0.0"
@@ -15,11 +15,11 @@
         "@spoke-ph/changelog": "1.2.0"
       },
       "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.0.0",
-        "@typescript-eslint/parser": "^5.0.0",
-        "babel-eslint": "^10.0.3",
-        "eslint": "^7.21.0",
-        "eslint-plugin-flowtype": "^5.3.1"
+        "@typescript-eslint/eslint-plugin": ">= 5.0.0",
+        "@typescript-eslint/parser": ">= 5.0.0",
+        "babel-eslint": ">= 10.0.3",
+        "eslint": ">= 7.21.0",
+        "eslint-plugin-flowtype": ">= 5.3.1"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-spoke",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Spoke's ESLint config",
   "license": "Unlicense",
   "author": {
@@ -27,11 +27,11 @@
     "@spoke-ph/changelog": "1.2.0"
   },
   "peerDependencies": {
-    "babel-eslint": "^10.0.3",
-    "eslint": "^7.21.0",
-    "eslint-plugin-flowtype": "^5.3.1",
-    "@typescript-eslint/parser": "^5.0.0",
-    "@typescript-eslint/eslint-plugin": "^5.0.0"
+    "babel-eslint": ">= 10.0.3",
+    "eslint": ">= 7.21.0",
+    "eslint-plugin-flowtype": ">= 5.3.1",
+    "@typescript-eslint/parser": ">= 5.0.0",
+    "@typescript-eslint/eslint-plugin": ">= 5.0.0"
   },
   "dependencies": {
     "eslint-plugin-simple-import-sort": "^7.0.0"


### PR DESCRIPTION
We don't necessarily need to fix the peer dependencies, and this way this library won't prevent people from upgrading to new major versions of our peer deps.

Also my previous PR didn't actually fix (all) the peer deps issues that I wanted to fix because npm doesn't blow up when it should blow up 😭 