### PR TITLE
Don't require explicit return types on function expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This repository adheres to semantic versioning and follows the conventions of [k
 
 ## [Unreleased]
 
+## [1.2.0] - 2022-10-05
+### Changed
+- Dont require explicit return types on function expressions
+  - ESLint rule `@typescript-eslint/explicit-function-return-type` now has `allowExpressions: true`
+  - See [here](https://typescript-eslint.io/rules/explicit-function-return-type/#options) for more info
+
 ## [1.1.0] - 2022-10-03
 ### Changed
 - Peer dependencies can now use newer major versions
@@ -83,7 +89,8 @@ This repository adheres to semantic versioning and follows the conventions of [k
 - `babel`, `common`, `flow`, `mocha`, `node` and `typecript` Configs
 - `common`, `flowService` and `typescriptService` Presets
 
-[Unreleased]: https://github.com/spoke-ph/eslint-config-spoke/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/spoke-ph/eslint-config-spoke/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/spoke-ph/eslint-config-spoke/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/spoke-ph/eslint-config-spoke/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/spoke-ph/eslint-config-spoke/compare/v0.11.0...v1.0.0
 [0.11.0]: https://github.com/spoke-ph/eslint-config-spoke/compare/v0.10.0...v0.11.0

--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -82,7 +82,12 @@ module.exports = {
           // enable the rule specifically for TypeScript files
           "files": ["*.ts", "*.mts", "*.cts", "*.tsx"],
           "rules": {
-            "@typescript-eslint/explicit-function-return-type": ["error"]
+              "@typescript-eslint/explicit-function-return-type": [
+                  "error",
+                  {
+                      "allowExpressions": true
+                  }
+              ]
           }
         }
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-config-spoke",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-config-spoke",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Unlicense",
       "dependencies": {
         "eslint-plugin-simple-import-sort": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-spoke",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Spoke's ESLint config",
   "license": "Unlicense",
   "author": {


### PR DESCRIPTION

```typescript
//still bad
export const f = () => 3;

//still bad
export function g() {
  return 3;
}

//still bad
export const h = function() {
  return 3;
};

// good
export const i = (): string => R.cond([
  [(n) => !!n, () => "a"]
])(1);

// good (required before, but now can do above (i) instead)
export const j = (): string => R.cond([
  [(n): boolean => !!n, (): string => "a"]
])(1);

// still bad
export const k = (): string => R.cond([
  [(n) => 2, () => "a"]
])(1);

// still bad
export const l = (): string => {
  const ll = () => "a";
  return ll();
};
```